### PR TITLE
feat(ui): align Navbar/Footer, homepage container, and Card with design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,31 @@
 import React from 'react'
+import Card from "../components/Card";
+
 
 const Home = () => {
     return (
-        <h1 className ="text-heading-1 font-jost">Nike</h1>
+        <main className="mx-auto max-w-7xl px-4 md:px-6 py-8">
+            <h1 className="text-heading-1 font-jost mb-6">Nike</h1>
+
+            {/* Product Grid Demo */} 
+            {/* Replace imageSrc with real product images in /public when available */}
+            <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {[
+                    { title: "Nike Air Force 1 Mid '07", imageSrc: "/vercel.svg", price: "$98.30", brand: "Men's Shoes", badge: { label: "Best Seller", color: "red" as const } },
+                    { title: "Nike Court Vision Low Next Nature", imageSrc: "/vercel.svg", price: "$98.30", brand: "Men's Shoes", badge: { label: "Extra 20% off", color: "green" as const } },
+                    { title: "Nike Dunk Low Retro", imageSrc: "/vercel.svg", price: "$98.30", brand: "Men's Shoes", badge: { label: "Extra 10% off", color: "green" as const } },
+                ].map((p) => (
+                    <Card
+                        key={p.title}
+                        title={p.title}
+                        imageSrc={p.imageSrc}
+                        price={p.price}
+                        brand={p.brand}
+                        badge={p.badge}
+                    />
+                ))}
+            </section>
+        </main>
     )
 }
 export default Home

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -33,15 +33,15 @@ export default function Card({
 }: CardProps) {
   const badgeBg =
     badge?.color === "red"
-      ? "bg-[var(--color-red)]/10 text-[var(--color-red)]"
+      ? "text-[var(--color-red)]"
       : badge?.color === "green"
-      ? "bg-[var(--color-green)]/10 text-[var(--color-green)]"
-      : "bg-[var(--color-orange)]/10 text-[var(--color-orange)]";
+      ? "text-[var(--color-green)]"
+      : "text-[var(--color-orange)]";
 
   return (
     <article
       className={cx(
-        "group relative flex flex-col overflow-hidden rounded-xl border border-[var(--color-light-300)] bg-[var(--color-light-100)] shadow-sm",
+        "group relative flex flex-col overflow-hidden rounded-xl border border-[var(--color-light-300)] bg-transparent shadow-sm",
         className
       )}
     >
@@ -56,37 +56,28 @@ export default function Card({
         />
         {badge && (
           <span
-            className={`absolute left-3 top-3 rounded-full px-3 py-1 text-[12px] font-medium ${badgeBg}`}
+            className={`absolute left-3 top-3 rounded-full bg-white px-3 py-[6px] text-[12px] font-medium shadow-sm ${badgeBg}`}
           >
             {badge.label}
           </span>
         )}
       </div>
 
-      <div className="flex flex-1 flex-col gap-2 p-4">
-        <h3 className="text-[var(--color-dark-900)] text-base font-medium">
-          {title}
-        </h3>
+      <div className="flex flex-1 flex-col gap-1 bg-[var(--color-dark-900)] px-4 py-3 text-[var(--color-light-100)]">
+        <div className="flex items-center justify-between">
+          <h3 className="truncate text-[15px] font-medium">{title}</h3>
+          <span className="text-[13px] text-[var(--color-light-400)]">
+            {typeof price === "number" ? `$${price}` : price}
+          </span>
+        </div>
+        {brand && (
+          <p className="text-[13px] text-[var(--color-light-400)]">{brand}</p>
+        )}
         {description && (
-          <p className="line-clamp-2 text-[var(--color-dark-700)] text-sm">
+          <p className="line-clamp-2 text-[12px] text-[var(--color-light-500)]">
             {description}
           </p>
         )}
-        <div className="mt-auto flex items-center justify-between">
-          <span className="text-[var(--color-dark-900)] text-lg font-semibold">
-            {typeof price === "number" ? `$${price}` : price}
-          </span>
-          {brand && (
-            <span className="text-[var(--color-dark-500)] text-sm">{brand}</span>
-          )}
-        </div>
-        <a
-          href={href}
-          className="mt-3 inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-800"
-          aria-label={`View ${title}`}
-        >
-          View
-        </a>
       </div>
     </article>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,14 +29,14 @@ const columns = [
 export default function Footer() {
   return (
     <footer className="w-full bg-[var(--color-dark-900)] text-[var(--color-light-100)]">
-      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-8 px-4 py-10 md:grid-cols-12 md:px-6 md:py-14">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-4 py-12 md:grid-cols-12 md:px-6 md:py-16">
         <div className="md:col-span-2">
           <Image
             src="/logo-inverse.svg"
             alt="Logo"
-            width={36}
-            height={36}
-            className="h-9 w-9"
+            width={40}
+            height={40}
+            className="h-10 w-10"
           />
         </div>
 
@@ -51,7 +51,7 @@ export default function Footer() {
                   <li key={l}>
                     <Link
                       href="#"
-                      className="text-[var(--color-light-400)] hover:text-[var(--color-light-200)] text-sm"
+                      className="text-[var(--color-light-500)] hover:text-[var(--color-light-200)] text-sm"
                     >
                       {l}
                     </Link>
@@ -82,24 +82,29 @@ export default function Footer() {
 
       <div className="border-t border-white/10">
         <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 py-6 md:flex-row md:px-6">
-          <p className="text-[var(--color-light-400)] text-xs">
-            © {new Date().getFullYear()} KroDT. All rights reserved.
+          <p className="text-[var(--color-light-500)] text-xs">
+            © {new Date().getFullYear()} Nike, Inc. All Rights Reserved
           </p>
           <nav aria-label="Footer links">
-            <ul className="flex items-center gap-6 text-xs text-[var(--color-light-400)]">
+            <ul className="flex items-center gap-6 text-xs text-[var(--color-light-500)]">
               <li>
                 <Link href="#" className="hover:text-[var(--color-light-200)]">
-                  Privacy
+                  Guides
                 </Link>
               </li>
               <li>
                 <Link href="#" className="hover:text-[var(--color-light-200)]">
-                  Terms
+                  Terms of Sale
                 </Link>
               </li>
               <li>
                 <Link href="#" className="hover:text-[var(--color-light-200)]">
-                  Contact
+                  Terms of Use
+                </Link>
+              </li>
+              <li>
+                <Link href="#" className="hover:text-[var(--color-light-200)]">
+                  Nike Privacy Policy
                 </Link>
               </li>
             </ul>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,9 +27,9 @@ export default function Navbar() {
           <Image
             src="/logo.svg"
             alt="Logo"
-            width={28}
-            height={28}
-            className="h-7 w-7"
+            width={32}
+            height={32}
+            className="h-8 w-8"
           />
         </Link>
 
@@ -52,7 +52,7 @@ export default function Navbar() {
           </svg>
         </button>
 
-        <ul className="hidden items-center gap-8 md:flex">
+        <ul className="hidden items-center gap-10 md:flex">
           {navItems.map((item) => (
             <li key={item.label}>
               <Link


### PR DESCRIPTION
# feat(ui): align Navbar/Footer, homepage container, and Card with design

## Summary
Updates UI components to match provided design mockups:

- **Navbar**: Increased logo size (28px→32px) and navigation spacing for design alignment
- **Footer**: Updated spacing, logo size, copyright text (KroDT→Nike, Inc.), and bottom links to match mockup labels
- **Card**: Complete redesign with white badges, dark info section overlay, price repositioning, and removed CTA button
- **Homepage**: Added proper container constraints (max-w-7xl) and demo product grid

## Review & Testing Checklist for Human
**⚠️ Visual verification required** - 4 critical items:

- [ ] **Card component compatibility**: Verify Card changes don't break other parts of the app that use this component
- [ ] **Visual design accuracy**: Components match the provided design mockups (especially the dark Card info sections and white badges)
- [ ] **Branding change intentional**: Footer copyright changed from "KroDT" to "Nike, Inc." - confirm this rebrand is intended
- [ ] **Mobile responsiveness**: Test hamburger menu, grid layouts, and touch targets on mobile devices

### Recommended Test Plan
1. Set `DATABASE_URL` in `.env.local` to enable `npm run dev`
2. Navigate to homepage - verify product grid displays correctly with placeholder cards
3. Test navbar on mobile (hamburger menu functionality)
4. Scroll to footer - verify all links and spacing look correct
5. Check if Card component is used elsewhere in the app and test those pages

### Notes
- **Placeholder data warning**: Homepage uses hardcoded product array with "/vercel.svg" placeholder images - replace with real product data and images
- Build currently fails without `DATABASE_URL` environment variable
- Removed "View" CTA button from cards per design - confirm this UX change is intended
- All href attributes remain as "#" placeholders pending real route implementation

**Link to Devin run:** https://app.devin.ai/sessions/583ea6cceedc4d249b4a987a03a54081  
**Requested by:** Edward Du (@MELXZQ)