### PR TITLE
Auth: remove duplicate CTA and ensure clean root route wiring

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -24,12 +24,6 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
       <main className="bg-[var(--color-light-100)] flex items-center justify-center py-10">
         <div className="w-full max-w-md px-6 relative">
-          <div className="absolute right-6 -top-3 hidden md:block text-sm text-[var(--color-dark-700)]">
-            <span>Already have an account? </span>
-            <Link href="/sign-in" className="underline hover:opacity-80">
-              Sign In
-            </Link>
-          </div>
           {children}
         </div>
       </main>


### PR DESCRIPTION
# Auth: remove duplicate CTA and ensure clean root route wiring

## Summary
Removes duplicate "Already have an account? Sign In" call-to-action from the auth layout that was causing visual duplication on auth pages. The CTA logic now lives solely within the AuthForm component, which provides context-aware prompts (sign-in shows "New to Nike? Create an account", sign-up shows "Already have an account? Sign In").

## Review & Testing Checklist for Human
- [ ] **Verify no duplicate CTAs**: Check `/sign-in` and `/sign-up` pages to confirm only one CTA appears per page
- [ ] **Test CTA functionality**: Click the remaining CTA links to ensure navigation between sign-in and sign-up works correctly  
- [ ] **Visual regression check**: Confirm auth page layout still looks correct without the removed top-right CTA

### Test Plan
1. Navigate to `/sign-in` - should show "New to Nike? Create an account" link only
2. Click the link to verify it navigates to `/sign-up`
3. On `/sign-up` page - should show "Already have an account? Sign In" link only  
4. Click the link to verify it navigates back to `/sign-in`
5. Test on mobile viewport to ensure responsive behavior is intact

### Notes
- This addresses the duplicate CTA issue reported during testing
- CTA logic is now centralized in the AuthForm component for better maintainability
- No functional changes to authentication flow, purely UI cleanup

**Link to Devin run**: https://app.devin.ai/sessions/b50797aaed064efeb2dca3c9831ec8c1  
**Requested by**: Edward Du (@MELXZQ)