### PR TITLE
Fix: serve '/' from (root)/page.tsx (remove app/page.tsx)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,0 @@
-export { default } from "./(root)/page";


### PR DESCRIPTION
# Fix: serve '/' from (root)/page.tsx (remove app/page.tsx)

## Summary
Removes the explicit `src/app/page.tsx` re-export file to allow the home route "/" to resolve directly from `src/app/(root)/page.tsx`. This change relies on Next.js App Router's route group behavior where `(root)` is URL-ignored, making `app/(root)/page.tsx` serve the root route without needing an explicit re-export.

**Previous behavior:** `app/page.tsx` re-exported from `app/(root)/page.tsx`  
**New behavior:** `app/(root)/page.tsx` serves "/" directly (route groups are URL-ignored)

## Review & Testing Checklist for Human
- [ ] **Verify homepage loads**: Navigate to "/" and confirm it renders the home page content
- [ ] **Check layout rendering**: Ensure the homepage displays with Navbar and Footer from the (root) layout
- [ ] **Test auth pages still work**: Verify `/sign-in` and `/sign-up` pages continue to function properly
- [ ] **Optional: Production build test**: Run `npm run build` to ensure no build errors with the routing change

### Notes
- This change was requested to fix homepage loading issues while keeping auth pages functional
- Testing was limited due to browser/tunnel connectivity issues during development
- Route group behavior is Next.js App Router specific - ensure your Next.js version supports this pattern

**Link to Devin run:** https://app.devin.ai/sessions/b50797aaed064efeb2dca3c9831ec8c1  
**Requested by:** Edward Du (@MELXZQ)