### PR TITLE
Product Details Page: server-rendered layout with client gallery/variants/sizes + recommendations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "better-auth": "^1.3.26",
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.44.6",
+        "lucide-react": "^0.545.0",
         "next": "15.5.4",
         "query-string": "^9.3.1",
         "react": "19.1.0",
@@ -6000,6 +6001,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.545.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz",
+      "integrity": "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "better-auth": "^1.3.26",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.44.6",
+    "lucide-react": "^0.545.0",
     "next": "15.5.4",
     "query-string": "^9.3.1",
     "react": "19.1.0",

--- a/src/app/(root)/page.tsx
+++ b/src/app/(root)/page.tsx
@@ -58,6 +58,7 @@ const Home = async () => {
                             imageSrc={p.imageSrc}
                             price={p.price}
                             brand={p.subtitle}
+                            href={`/products/${p.id}`}
                             badge={
                                 p.badge
                                     ? { label: p.badge.label, color: p.badge.tone as "red" | "green" | "orange" }

--- a/src/app/(root)/products/[id]/page.tsx
+++ b/src/app/(root)/products/[id]/page.tsx
@@ -1,0 +1,224 @@
+"use server";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Heart, ShoppingBag, Star } from "lucide-react";
+import ProductGallery from "@/components/ProductGallery";
+import SizePicker from "@/components/SizePicker";
+import CollapsibleSection from "@/components/CollapsibleSection";
+import Card from "@/components/Card";
+
+type ProductImage = { src: string; alt: string };
+type Variant = { id: string; name: string; color: string; images: ProductImage[]; swatch: string };
+type Product = {
+  id: string;
+  title: string;
+  subtitle: string;
+  price: number;
+  compareAt?: number;
+  description: string;
+  features: string[];
+  variants: Variant[];
+};
+
+const MOCK_PRODUCTS: Record<string, Product> = {
+  "1": {
+    id: "1",
+    title: "Nike Air Max 90 SE",
+    subtitle: "Women's Shoes",
+    price: 140,
+    compareAt: 170,
+    description:
+      "The Air Max 90 stays true to its running roots with the iconic Waffle sole. Stitched overlays and textured accents create the '90s look you love. Complete with romantic hues, its visible Air cushioning adds comfort to your journey.",
+    features: [
+      "Padded collar",
+      "Foam midsole",
+      "Shown: Dark Team Red/Platinum Tint/Pure Platinum/White",
+      "Style: HM9451-600",
+    ],
+    variants: [
+      {
+        id: "v1",
+        name: "Dark Team Red",
+        color: "#6d1a1a",
+        swatch: "/swatches/red.png",
+        images: [
+          { src: "/shoes/detail/airmax90-1.jpg", alt: "Air Max 90 SE angle 1" },
+          { src: "/shoes/detail/airmax90-2.jpg", alt: "Air Max 90 SE angle 2" },
+          { src: "/shoes/detail/airmax90-3.jpg", alt: "Air Max 90 SE angle 3" },
+          { src: "/shoes/detail/airmax90-4.jpg", alt: "Air Max 90 SE angle 4" },
+          { src: "/shoes/detail/airmax90-5.jpg", alt: "Air Max 90 SE angle 5" },
+        ],
+      },
+      {
+        id: "v2",
+        name: "Pure Platinum",
+        color: "#cfd3d6",
+        swatch: "/swatches/gray.png",
+        images: [
+          { src: "/shoes/detail/airmax90-gray-1.jpg", alt: "Air Max 90 SE gray 1" },
+          { src: "/shoes/detail/airmax90-gray-2.jpg", alt: "Air Max 90 SE gray 2" },
+        ],
+      },
+      {
+        id: "v3",
+        name: "White",
+        color: "#ffffff",
+        swatch: "/swatches/white.png",
+        images: [
+          { src: "/shoes/detail/airmax90-white-1.jpg", alt: "Air Max 90 SE white 1" },
+        ],
+      },
+    ],
+  },
+};
+
+const RECOMMENDED = [
+  {
+    id: 2,
+    title: "Nike Air Force 1 Mid '07",
+    description: "Men's Shoes",
+    imageSrc: "/shoes/shoe-1.jpg",
+    price: 98.3,
+    brand: "6 Colour",
+    badge: { label: "Best Seller", color: "orange" as const },
+  },
+  {
+    id: 3,
+    title: "Nike Court Vision Low Next Nature",
+    description: "Men's Shoes",
+    imageSrc: "/shoes/shoe-2.webp",
+    price: 98.3,
+    brand: "4 Colour",
+    badge: { label: "Extra 20% off", color: "green" as const },
+  },
+  {
+    id: 4,
+    title: "Nike Dunk Low Retro",
+    description: "Men's Shoes",
+    imageSrc: "/shoes/shoe-3.webp",
+    price: 98.3,
+    brand: "6 Colour",
+    badge: { label: "Extra 10% off", color: "green" as const },
+  },
+];
+
+export default function ProductDetailPage({ params }: { params: { id: string } }) {
+  const product = MOCK_PRODUCTS[params.id] ?? Object.values(MOCK_PRODUCTS)[0];
+
+  const hasAnyImages = product.variants.some((v) => v.images && v.images.length > 0);
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 md:px-6 py-6">
+      <nav aria-label="Breadcrumb" className="mb-6 text-sm text-[var(--color-dark-700)]">
+        <Link href="/" className="hover:underline">Home</Link>
+        <span className="mx-2">/</span>
+        <Link href="/products" className="hover:underline">Products</Link>
+        <span className="mx-2">/</span>
+        <span aria-current="page" className="text-[var(--color-dark-900)]">{product.title}</span>
+      </nav>
+
+      <section className="grid grid-cols-1 lg:grid-cols-[520px_minmax(0,1fr)] gap-8 lg:gap-12">
+        <div>
+          {hasAnyImages ? (
+            <ProductGallery variants={product.variants} />
+          ) : (
+            <div className="aspect-square w-full rounded-xl border border-light-300 bg-light-200" />
+          )}
+        </div>
+
+        <div className="flex flex-col">
+          <header className="mb-4">
+            <h1 className="text-heading-3 text-dark-900">{product.title}</h1>
+            <p className="text-[var(--color-dark-700)] text-sm">{product.subtitle}</p>
+          </header>
+
+          <div className="mb-5 flex items-end gap-3">
+            <p className="text-2xl font-semibold text-dark-900">${product.price}</p>
+            {product.compareAt && (
+              <>
+                <p className="text-lg line-through text-[var(--color-light-400)]">${product.compareAt}</p>
+                <span className="rounded-full bg-[var(--color-green)]/10 px-2.5 py-1 text-xs font-medium text-[var(--color-green)]">
+                  {Math.round(((product.compareAt - product.price) / product.compareAt) * 100)}% off
+                </span>
+              </>
+            )}
+          </div>
+
+          <div className="mb-6">
+            {/* Variant swatches and gallery are handled within ProductGallery */}
+          </div>
+
+          <div className="mb-6">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-medium">Select Size</span>
+              <button className="text-sm underline">Size Guide</button>
+            </div>
+            <SizePicker sizes={["5", "5.5", "6", "6.5", "7", "7.5", "8", "8.5", "9", "9.5", "10"]} />
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <button
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-[var(--color-dark-900)] px-6 py-3 text-white hover:opacity-90"
+              aria-label="Add to Bag"
+            >
+              <ShoppingBag className="h-5 w-5" />
+              Add to Bag
+            </button>
+            <button
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-light-300 bg-white px-6 py-3 text-dark-900 hover:bg-light-200"
+              aria-label="Favorite"
+            >
+              <Heart className="h-5 w-5" />
+              Favorite
+            </button>
+          </div>
+
+          <div className="mt-8 divide-y divide-light-300">
+            <CollapsibleSection title="Product Details" defaultOpen>
+              <p className="text-[15px] text-dark-700 mb-4">{product.description}</p>
+              <ul className="list-disc pl-5 space-y-1 text-sm text-dark-700">
+                {product.features.map((f, i) => (
+                  <li key={i}>{f}</li>
+                ))}
+              </ul>
+            </CollapsibleSection>
+
+            <CollapsibleSection title="Shipping & Returns">
+              <p className="text-sm text-dark-700">
+                Free standard shipping and 30-day returns for Nike Members.
+              </p>
+            </CollapsibleSection>
+
+            <CollapsibleSection title="Reviews (10)">
+              <div className="flex items-center gap-1 text-dark-900">
+                {[...Array(5)].map((_, i) => (
+                  <Star key={i} className="h-4 w-4 fill-current" />
+                ))}
+              </div>
+              <p className="mt-2 text-sm text-dark-700">No reviews yet.</p>
+            </CollapsibleSection>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-14">
+        <h2 className="mb-4 text-heading-3">You Might Also Like</h2>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {RECOMMENDED.map((p) => (
+            <Card
+              key={p.id}
+              title={p.title}
+              description={p.description}
+              imageSrc={p.imageSrc}
+              price={p.price}
+              brand={p.brand}
+              badge={p.badge}
+              href={`/products/${p.id}`}
+            />
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(root)/products/[id]/page.tsx
+++ b/src/app/(root)/products/[id]/page.tsx
@@ -1,7 +1,4 @@
-"use server";
-
 import Link from "next/link";
-import Image from "next/image";
 import { Heart, ShoppingBag, Star } from "lucide-react";
 import ProductGallery from "@/components/ProductGallery";
 import SizePicker from "@/components/SizePicker";

--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -66,6 +66,7 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
                   imageSrc={p.imageUrl || '/placeholder-image.jpg'}
                   price={p.minPrice === p.maxPrice ? p.minPrice : `$${p.minPrice} - $${p.maxPrice}`}
                   brand={p.brand ?? undefined}
+                  href={`/products/${p.id}`}
                 />
               ))}
             </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -39,7 +39,8 @@ export default function Card({
       : "text-[var(--color-orange)]";
 
   return (
-    <article
+    <a
+      href={href}
       className={cx(
         "group relative flex flex-col overflow-hidden rounded-xl border border-[var(--color-light-300)] bg-transparent shadow-sm",
         className
@@ -79,6 +80,6 @@ export default function Card({
           </p>
         )}
       </div>
-    </article>
+    </a>
   );
 }

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+interface Props {
+  title: string;
+  children?: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export default function CollapsibleSection({ title, children, defaultOpen = false }: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <section className="py-5 first:pt-0">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <h3 className="text-[16px] font-medium text-dark-900">{title}</h3>
+        <ChevronDown
+          className={`h-5 w-5 transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      {open && <div className="mt-4">{children}</div>}
+    </section>
+  );
+}

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 "use client";
+import React from "react";
 
 import { ChevronDown } from "lucide-react";
 import { useState } from "react";

--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+"use client";
+
+import Image from "next/image";
+import { ImageOff, ChevronLeft, ChevronRight, Check } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type ProductImage = { src: string; alt: string };
+type Variant = { id: string; name: string; color: string; images: ProductImage[]; swatch: string };
+
+interface Props {
+  variants: Variant[];
+}
+
+const isValidSrc = (src: string | undefined | null) => Boolean(src && typeof src === "string");
+
+export default function ProductGallery({ variants }: Props) {
+  const validVariants = useMemo(
+    () =>
+      variants
+        .map((v) => ({ ...v, images: (v.images || []).filter((img) => isValidSrc(img.src)) }))
+        .filter((v) => v.images.length > 0),
+    [variants]
+  );
+
+  const [variantIdx, setVariantIdx] = useState(0);
+  const images = validVariants[variantIdx]?.images ?? [];
+  const [imgIdx, setImgIdx] = useState(0);
+  const thumbRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    setImgIdx(0);
+  }, [variantIdx]);
+
+  const next = () => setImgIdx((i) => (i + 1) % Math.max(images.length, 1));
+  const prev = () => setImgIdx((i) => (i - 1 + Math.max(images.length, 1)) % Math.max(images.length, 1));
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowRight") next();
+    if (e.key === "ArrowLeft") prev();
+  };
+
+  if (validVariants.length === 0) {
+    return (
+      <div className="flex aspect-square w-full items-center justify-center rounded-xl border border-light-300 bg-light-200">
+        <ImageOff className="h-10 w-10 text-light-400" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  const main = images[imgIdx];
+
+  return (
+    <div className="grid grid-cols-[72px_1fr] gap-4 lg:gap-6">
+      <div className="flex flex-col gap-3 overflow-y-auto pr-1">
+        {images.map((img, i) => (
+          <button
+            key={img.src + i}
+            ref={(el) => {
+              thumbRefs.current[i] = el;
+            }}
+            className={`relative aspect-square overflow-hidden rounded-lg border ${
+              i === imgIdx ? "border-dark-900" : "border-light-300"
+            } focus:outline-none focus:ring-2 focus:ring-dark-900`}
+            onClick={() => setImgIdx(i)}
+            aria-label={`View image ${i + 1}`}
+          >
+            <Image
+              src={img.src}
+              alt={img.alt}
+              fill
+              className="object-cover"
+              sizes="96px"
+            />
+          </button>
+        ))}
+      </div>
+
+      <div
+        className="relative rounded-xl border border-light-300 bg-light-200"
+        tabIndex={0}
+        onKeyDown={handleKey}
+        aria-live="polite"
+      >
+        {main ? (
+          <Image
+            src={main.src}
+            alt={main.alt}
+            className="rounded-xl object-cover"
+            fill
+            sizes="(max-width: 1024px) 100vw, 520px"
+            priority
+          />
+        ) : (
+          <div className="flex aspect-square w-full items-center justify-center">
+            <ImageOff className="h-10 w-10 text-light-400" aria-hidden="true" />
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-between p-3">
+          <button
+            type="button"
+            onClick={prev}
+            aria-label="Previous image"
+            className="pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/90 shadow"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            aria-label="Next image"
+            className="pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/90 shadow"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="mt-4">
+          <div className="flex items-center gap-2">
+            {validVariants.map((v, i) => (
+              <button
+                key={v.id}
+                onClick={() => setVariantIdx(i)}
+                aria-label={`Select color ${v.name}`}
+                className={`relative h-8 w-8 overflow-hidden rounded-full border ${
+                  i === variantIdx ? "border-dark-900" : "border-light-300"
+                } focus:outline-none focus:ring-2 focus:ring-dark-900`}
+              >
+                <Image src={v.swatch} alt={v.name} fill sizes="32px" className="object-cover" />
+                {i === variantIdx && (
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <Check className="h-4 w-4 text-white drop-shadow" />
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 "use client";
+import React from "react";
 
 import Image from "next/image";
 import { ImageOff, ChevronLeft, ChevronRight, Check } from "lucide-react";

--- a/src/components/SizePicker.tsx
+++ b/src/components/SizePicker.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  sizes: string[];
+}
+
+export default function SizePicker({ sizes }: Props) {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
+      {sizes.map((s) => {
+        const active = selected === s;
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setSelected(s)}
+            className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-dark-900 ${
+              active ? "border-dark-900" : "border-light-300"
+            }`}
+            aria-pressed={active}
+          >
+            {s}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SizePicker.tsx
+++ b/src/components/SizePicker.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 "use client";
-
+import React from "react";
 import { useState } from "react";
 
 interface Props {


### PR DESCRIPTION
# Product Details Page: server-rendered layout with client gallery/variants/sizes + recommendations

## Summary
Adds a new server-rendered product details page at `/products/[id]` with isolated client components for interactive elements. The page includes a product gallery with variant swatches, size picker, collapsible sections (details/shipping/reviews), and "You Might Also Like" recommendations. Also updates existing product cards to link to the new detail pages.

**Key Files:**
- `src/app/(root)/products/[id]/page.tsx` - Server-rendered product detail page
- `src/components/ProductGallery.tsx` - Interactive gallery with thumbnails and color swatches  
- `src/components/SizePicker.tsx` - Size selection grid
- `src/components/CollapsibleSection.tsx` - Expandable content sections
- Modified `Card.tsx` to be clickable links to product details

## Review & Testing Checklist for Human
**⚠️ Critical - 4 items to verify before merging:**

- [ ] **Test complete navigation flow** - Click product cards from home page and `/products` to verify they navigate to `/products/[id]` correctly
- [ ] **Verify gallery fallback states** - The mock data references image paths like `/shoes/detail/airmax90-1.jpg` that likely don't exist - confirm the ImageOff fallback renders gracefully when images are missing
- [ ] **Test all interactive components** - Gallery navigation (thumbnails, arrow keys, prev/next buttons), variant swatch selection, size picker, and collapsible sections all work properly
- [ ] **Visual design verification** - Compare against the provided design screenshot to ensure pixel-perfect layout, especially on mobile/tablet breakpoints

### Notes
- Uses hardcoded mock product data with image paths that may not exist in `/public`
- Added lucide-react dependency for icons
- Changed Card component from `<article>` to `<a>` for navigation - verify this doesn't break accessibility
- All interactive elements are properly isolated in client components while maintaining server-rendered page structure

**Session:** https://app.devin.ai/sessions/2edf59b5e1d84f4aad9366fbd706870c  
**Requested by:** Edward Du (@MELXZQ)